### PR TITLE
Provide multiarch image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,17 @@ before_install:
   - sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) edge"
   - sudo apt-get update
   - sudo apt-get -y -o Dpkg::Options::="--force-confnew" install docker-ce
+  - export ARCH=$(uname -m)
+  - case $ARCH in
+      armv6*) ARCH="arm-v6";;
+      armv7*) ARCH="arm-v7";;
+      aarch64) ARCH="arm64";;
+      x86_64) ARCH="amd64";;
+    esac
+  - curl -L --output /docker-buildx "https://github.com/docker/buildx/releases/download/v${BUILDX_VERSION}/buildx-v${BUILDX_VERSION}.linux-${ARCH}"
+  - chmod a+x /docker-buildx
+  - mkdir -p /usr/lib/docker/cli-plugins
+  - cp /docker-buildx /usr/lib/docker/cli-plugins/docker-buildx
   - docker context create something
   - docker run --rm --privileged multiarch/qemu-user-static:register --reset
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: bash
 
+dist: bionic
+
 env:
   - BUILDX_VERSION=0.4.2 DOCKER_VERSION=test
   - BUILDX_VERSION=0.4.2 DOCKER_VERSION=stable
@@ -13,15 +15,24 @@ env:
   - BUILDX_VERSION=0.3.1 DOCKER_VERSION=test
   - BUILDX_VERSION=0.3.1 DOCKER_VERSION=stable
   - BUILDX_VERSION=0.3.1 DOCKER_VERSION=19.03
+  - DOCKER_CLI_EXPERIMENTAL=enabled
 
-services:
-  - docker
+before_install:
+  - sudo rm -rf /var/lib/apt/lists/*
+  - curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+  - lsb_release -cs
+  - sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) edge"
+  - sudo apt-get update
+  - sudo apt-get -y -o Dpkg::Options::="--force-confnew" install docker-ce
+  - docker context create something
+  - docker run --rm --privileged multiarch/qemu-user-static:register --reset
 
 branches:
   only:
     - master
 
 script:
-  - docker build --build-arg BUILDX_VERSION=$BUILDX_VERSION --build-arg DOCKER_VERSION=$DOCKER_VERSION -t jdrouet/docker-with-buildx:$DOCKER_VERSION-$BUILDX_VERSION .
+  - docker buildx create --use --name buildx-builder something
+  - docker buildx inspect --bootstrap
   - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
-  - docker push jdrouet/docker-with-buildx:$DOCKER_VERSION-$BUILDX_VERSION
+  - docker buildx build --platform linux/amd64,linux/arm/v7 --push --build-arg BUILDX_VERSION=$BUILDX_VERSION --build-arg DOCKER_VERSION=$DOCKER_VERSION -t jdrouet/docker-with-buildx:$DOCKER_VERSION-$BUILDX_VERSION .

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,10 +31,10 @@ before_install:
       aarch64) ARCH="arm64";;
       x86_64) ARCH="amd64";;
     esac
-  - curl -L --output /docker-buildx "https://github.com/docker/buildx/releases/download/v${BUILDX_VERSION}/buildx-v${BUILDX_VERSION}.linux-${ARCH}"
-  - chmod a+x /docker-buildx
+  - curl -L --output docker-buildx "https://github.com/docker/buildx/releases/download/v${BUILDX_VERSION}/buildx-v${BUILDX_VERSION}.linux-${ARCH}"
+  - chmod a+x docker-buildx
   - mkdir -p /usr/lib/docker/cli-plugins
-  - cp /docker-buildx /usr/lib/docker/cli-plugins/docker-buildx
+  - cp docker-buildx /usr/lib/docker/cli-plugins/docker-buildx
   - docker context create something
   - docker run --rm --privileged multiarch/qemu-user-static:register --reset
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,9 +6,15 @@ FROM alpine AS fetcher
 RUN apk add curl
 
 ARG BUILDX_VERSION
-RUN curl -L \
+RUN ARCH=$(uname -m) && \
+  case $ARCH in \
+    armv6*) ARCH="arm-v6";; \
+    armv7*) ARCH="arm-v7";; \
+    aarch64) ARCH="arm64";; \
+    x86_64) ARCH="amd64";; \
+  esac && curl -L \
   --output /docker-buildx \
-  "https://github.com/docker/buildx/releases/download/v${BUILDX_VERSION}/buildx-v${BUILDX_VERSION}.linux-amd64"
+  "https://github.com/docker/buildx/releases/download/v${BUILDX_VERSION}/buildx-v${BUILDX_VERSION}.linux-${ARCH}"
 
 RUN chmod a+x /docker-buildx
 


### PR DESCRIPTION
Provide multiarch image, so that we can also build on RPI clusters. I use this image to build images in CI, but my runners are on RPI3 (and 4), so I would require this image to have multiarch support.

I know repo currently doesn't have license, but I am hoping on some, so that you allow contributions and re-usage?

Disclamer: I have taken all the examples from your repositories (https://github.com/jdrouet/docker-on-ci/blob/master/.travis.yml) in case you do not want to add a license, so you can actually claim the work.
